### PR TITLE
Fix error in patch when x is datetime

### DIFF
--- a/shadedErrorBar.m
+++ b/shadedErrorBar.m
@@ -173,9 +173,15 @@ function H = makePlot(x,y,errBar,lineProps,transparent,patchSaturation)
     yP(isnan(yP))=[];
 
 
-    H.patch=patch(xP,yP,1,'facecolor',patchColor, ...
+    if(isdatetime(x))
+        H.patch=patch(datenum(xP),yP,1,'facecolor',patchColor, ...
                   'edgecolor','none', ...
                   'facealpha',faceAlpha);
+    else
+        H.patch=patch(xP,yP,1,'facecolor',patchColor, ...
+                  'edgecolor','none', ...
+                  'facealpha',faceAlpha);
+    end
 
 
     %Make pretty edges around the patch. 


### PR DESCRIPTION
If x argument is a datetime, convert it to datenum to avoid error making the errorbar patch