### PR TITLE
Add: Open in MATLAB Online button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # shadedErrorBar
-[![View raacampbell/shadedErrorBar on File Exchange](https://www.mathworks.com/matlabcentral/images/matlab-file-exchange.svg)](https://uk.mathworks.com/matlabcentral/fileexchange/26311-raacampbell-shadederrorbar)
+[![View raacampbell/shadedErrorBar on File Exchange](https://www.mathworks.com/matlabcentral/images/matlab-file-exchange.svg)](https://uk.mathworks.com/matlabcentral/fileexchange/26311-raacampbell-shadederrorbar) [![Open in MATLAB Online](https://www.mathworks.com/images/responsive/global/open-in-matlab-online.svg)](https://matlab.mathworks.com/open/github/v1?repo=raacampbell/shadedErrorBar) 
 
 `shadedErrorBar` is a MATLAB function that creates a continuous shaded error region around a line rather than discrete bars. 
 The error region can either be specified explicitly or calculated on the fly based upon function handles. 


### PR DESCRIPTION
This PR adds the new Open in MATLAB Online badge to the README.

PS.

I love this project. It is one of my favorites to add to my MATLAB session.

We released a new Open in MATLAB Online feature. Anyone can open this in MATLAB Online from GitHub and run the demo.

We just blogged about and highlighted your project! [Open science and reusable research with MATLAB Online and GitHub](https://blogs.mathworks.com/matlab/2023/07/20/open-science-and-reusable-research-with-matlab-online-and-github/)